### PR TITLE
HCG conventions update 1

### DIFF
--- a/bin/SMHTT2016_em.cpp
+++ b/bin/SMHTT2016_em.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
   //! [part3]
   cb.AddObservations({"*"}, {"smh2016"}, {"13TeV"}, {"em"}, cats);
 
-  vector<string> bkg_procs = {"W","QCD","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"W","QCD","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e"))
     {
       bkg_procs.push_back("ZT");      
@@ -74,40 +74,40 @@ int main(int argc, char **argv)
   cb.AddProcesses({"*"}, {"smh2016"}, {"13TeV"}, {"em"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"ZH_htt125","WH_htt125"}});
+  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"ZH_htt","WH_htt"}});
   
   cb.AddProcesses(masses, {"smh2016"}, {"13TeV"}, {"em"}, sig_procs, cats, true);    
 
@@ -127,25 +127,25 @@ int main(int argc, char **argv)
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
-  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qqbar", "lnN", SystMap<>::init(1.021));
 
   //Electron ID efficiency
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","ZL","TTL","VVL","STT","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_e_2016","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","ZL","TTL","VVL","STT","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_e_2016","lnN",SystMap<>::init(1.02));
   cb.cp().process({"W"}).AddSyst(cb,"CMS_eff_e_2016","lnN",SystMap<>::init(1.01)); 
 
   //Muon ID efficiency
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","ZL","TTL","VVL","STT","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_m_2016","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","ZL","TTL","VVL","STT","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_m_2016","lnN",SystMap<>::init(1.02));
   cb.cp().process({"W"}).AddSyst(cb,"CMS_eff_m_2016","lnN",SystMap<>::init(1.01));
 
   // b-tagging efficiency: 5% in ttbar and 0.5% otherwise.
   cb.cp().process({"STT","STL","TTT","TTL"}).AddSyst(cb,"CMS_htt_eff_b_TT_2016","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"W","ZT","VVT","ZL","VVL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2016","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"W","ZT","VVT","ZL","VVL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2016","lnN",SystMap<>::init(1.005));
 
   // XSection Uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -156,14 +156,14 @@ int main(int argc, char **argv)
   cb.cp().process({"W"}).AddSyst(cb,"CMS_htt_jtoellFR_2016", "lnN", SystMap<>::init(1.20));
  
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2016", "lnN", SystMap<>::init(1.022));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.009));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_13TeV_2016", "lnN", SystMap<>::init(1.022));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.009));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.004));
 
   //Trigger uncertainties
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "CMS_trg_emu_2016", "lnN", SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "CMS_trg_emu_2016", "lnN", SystMap<>::init(1.02));
 
   //***********************************************************
   //shape uncertainties
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
       
       // Prefiring
       AddShapesIfNotEmpty({"CMS_prefiring"},
-			  JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}), 
+			  JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}), 
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -225,21 +225,21 @@ int main(int argc, char **argv)
       else
 	{
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2016","CMS_htt_boson_scale_met_0jet_2016"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"em_0jetlow","em_0jethigh"});
       
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_1jet_2016","CMS_htt_boson_scale_met_1jet_2016"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"em_boosted1"});
 
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_2jet_2016","CMS_htt_boson_scale_met_2jet_2016"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
@@ -266,27 +266,27 @@ int main(int argc, char **argv)
       std::cout<<"JES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_JetAbsolute","CMS_JetAbsolute_2016","CMS_JetBBEC1","CMS_JetBBEC1_2016","CMS_JetEC2","CMS_JetEC2_2016",
 	    "CMS_JetFlavorQCD","CMS_JetHF","CMS_JetHF_2016","CMS_JetRelativeBal"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.000,
 	TheFile,CategoryArgs);
       /*
       AddShapesIfNotEmpty({"CMS_JetEta3to5_2016","CMS_JetEta0to5_2016","CMS_JetRelativeBal_2016",
 	    "CMS_JetEta0to3_2016"},
-	    JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","W"}}),
+	    JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","W"}}),
 	&cb,
 	0.707,
 	TheFile,CategoryArgs);            
 
       AddShapesIfNotEmpty({"CMS_JetEta3to5","CMS_JetEta0to5","CMS_JetRelativeBal",
             "CMS_JetEta0to3"},
-        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","W"}}),
+        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","W"}}),
         &cb,
         0.707,
         TheFile,CategoryArgs);
 
       AddShapesIfNotEmpty({"CMS_JetEC2_2016"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","W"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","W"}}),
 			  &cb,
 			  1.000,
 			  TheFile,CategoryArgs);
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
       //JER
       std::cout<<"JER"<<std::endl;
       AddShapesIfNotEmpty({"CMS_JER_2016"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.000,
 			  TheFile,CategoryArgs);
@@ -304,7 +304,7 @@ int main(int argc, char **argv)
       std::cout<<"ggH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
 	    "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-	JoinStr({ggH_STXS,{"ggH_hww125"}}),
+	JoinStr({ggH_STXS,{"ggH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);            
@@ -313,21 +313,21 @@ int main(int argc, char **argv)
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
 
       //Muon Energy scale uncertainties
       AddShapesIfNotEmpty({"CMS_scale_m_etalt1p2","CMS_scale_m_eta1p2to2p1","CMS_scale_m_eta2p1to2p4"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","TTT","ZL","VVL","TTL","STT","STL","WH_htt125","ZH_htt125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","TTT","ZL","VVL","TTL","STT","STL","WH_htt","ZH_htt"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
 
       //Electron Energy scale uncertainties
       AddShapesIfNotEmpty({"CMS_scale_e"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","TTT","ZL","VVL","TTL","STT","STL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","TTT","ZL","VVL","TTL","STT","STL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
         &cb,
         1.00,
         TheFile,CategoryArgs);
@@ -352,16 +352,16 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_htt_emb_ttbar_2016", "shape", SystMap<>::init(1.00));
       
       //muon energy scale      
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_etalt1p2_2016","shape",SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_eta1p2to2p1_2016","shape",SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_eta2p1to2p4_2016","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_etalt1p2_2016","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_eta1p2to2p1_2016","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_eta2p1to2p4_2016","shape",SystMap<>::init(0.866));
       
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_etalt1p2_2016","shape",SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_eta1p2to2p1_2016","shape",SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_eta2p1to2p4_2016","shape",SystMap<>::init(0.500));
 
       //electron energy scale
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_e_2016","shape",SystMap<>::init(0.866));      
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_e_emb_2016","shape",SystMap<>::init(0.866));      
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_e_2016","shape",SystMap<>::init(0.500));      
     }

--- a/bin/SMHTT2016_et.cpp
+++ b/bin/SMHTT2016_et.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
   //! [part3]
   cb.AddObservations({"*"}, {"smh2016"}, {"13TeV"}, {"et"}, cats);
 
-  vector<string> bkg_procs = {"VVT","STT","TTT","jetFakes","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"VVT","STT","TTT","jetFakes","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e"))
     {
       bkg_procs.push_back("ZT");
@@ -68,40 +68,40 @@ int main(int argc, char **argv)
   cb.AddProcesses({"*"}, {"smh2016"}, {"13TeV"}, {"et"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"ZH_htt125","WH_htt125"}});
+  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"ZH_htt","WH_htt"}});
   
   cb.AddProcesses(masses, {"smh2016"}, {"13TeV"}, {"et"}, sig_procs, cats, true);    
 
@@ -121,26 +121,26 @@ int main(int argc, char **argv)
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
-  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
   
   //Electron ID efficiency
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_e_2016","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_e_2016","lnN",SystMap<>::init(1.02));
 
   // Against ele and against mu for real taus
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_t_againstemu_et_2016","lnN",SystMap<>::init(1.01));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_t_againstemu_et_2016","lnN",SystMap<>::init(1.01));
 
   // Trg efficiency. Can be a single lnN because only single ele trigger
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_singleeletrg_2016","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_singleeletrg_2016","lnN",SystMap<>::init(1.02));
 
   // b-tagging efficiency: 5% in ttbar and 0.5% otherwise.
   cb.cp().process({"TTT","TTL","STL","STT"}).AddSyst(cb,"CMS_htt_eff_b_TT_2016","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2016","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2016","lnN",SystMap<>::init(1.005));
 
   // XSection Uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -149,15 +149,15 @@ int main(int argc, char **argv)
   cb.cp().process({"ZT","ZL"}).AddSyst(cb,"CMS_htt_zjXsec", "lnN", SystMap<>::init(1.02));
 
   //Electron Fake Rate Uncertainty
-  //cb.cp().process({"ZL","VVL","TTL","STL"}).AddSyst(cb, "CMS_eFakeTau_2016 ", "lnN",SystMap<>::init(1.15));  
-  cb.cp().process({"VVL","TTL","STL"}).AddSyst(cb, "CMS_eFakeTau_2016 ", "lnN",SystMap<>::init(1.15));    
+  //cb.cp().process({"ZL","VVL","TTL","STL"}).AddSyst(cb, "CMS_fake_e_2016 ", "lnN",SystMap<>::init(1.15));  
+  cb.cp().process({"VVL","TTL","STL"}).AddSyst(cb, "CMS_fake_e_2016 ", "lnN",SystMap<>::init(1.15));    
   
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2016", "lnN", SystMap<>::init(1.022));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.009));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_13TeV_2016", "lnN", SystMap<>::init(1.022));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.009));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.004));
 
   cb.cp().process({"jetFakes"}).bin({"et_0jetlow"}).AddSyst(cb,"CMS_jetFakesNorm_0jetlow_et_2016","lnN",SystMap<>::init(1.05));
   cb.cp().process({"jetFakes"}).bin({"et_0jethigh"}).AddSyst(cb,"CMS_jetFakesNorm_0jethigh_et_2016","lnN",SystMap<>::init(1.05));
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
 
       // Prefiring
       AddShapesIfNotEmpty({"CMS_prefiring"},
-                          JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
       // Tau ID eff in pt bins
       std::cout<<"Tau ID eff"<<std::endl;
       AddShapesIfNotEmpty({"CMS_tauideff_pt30to35_2016","CMS_tauideff_pt35to40_2016","CMS_tauideff_ptgt40_2016"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -188,25 +188,25 @@ int main(int argc, char **argv)
       //E to tau fake energy scale and e to tau energy fake scale            
       /*
 	std::cout<<"ZLShapes"<<std::endl;
-      AddShapesIfNotEmpty({"CMS_scale_efaket_1prong_2016","CMS_scale_efaket_1prong1pizero_2016"},
+      AddShapesIfNotEmpty({"CMS_scale_fake_e_1prong_2016","CMS_scale_fake_e_1prong1pizero_2016"},
       {"ZL"},
 			  &cb,
 			  1.00,
 			  TheFile,CategoryArgs);
       */
       std::cout<<"ZLShapes"<<std::endl;
-      AddShapesIfNotEmpty({"CMS_scale_efaket_1prong_barrel_2016",
-	    "CMS_scale_efaket_1prong1pizero_barrel_2016",
-	    "CMS_scale_efaket_1prong_endcap_2016",
-	    "CMS_scale_efaket_1prong1pizero_endcap_2016"},
+      AddShapesIfNotEmpty({"CMS_scale_fake_e_1prong_barrel_2016",
+	    "CMS_scale_fake_e_1prong1pizero_barrel_2016",
+	    "CMS_scale_fake_e_1prong_endcap_2016",
+	    "CMS_scale_fake_e_1prong1pizero_endcap_2016"},
 			  {"ZL"},
 			  &cb,
 			  1.00,
 			  TheFile,CategoryArgs);
       
-      AddShapesIfNotEmpty({"CMS_norm_efaket_slice1_2016",
-	    "CMS_norm_efaket_slice2_2016",
-	    "CMS_norm_efaket_slice3_2016"},
+      AddShapesIfNotEmpty({"CMS_norm_fake_e_slice1_2016",
+	    "CMS_norm_fake_e_slice2_2016",
+	    "CMS_norm_fake_e_slice3_2016"},
 			  {"ZL"},
 			  &cb,
 			  1.00,
@@ -361,21 +361,21 @@ int main(int argc, char **argv)
       else
 	{
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2016","CMS_htt_boson_scale_met_0jet_2016"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"et_0jetlow","et_0jethigh"});
       
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_1jet_2016","CMS_htt_boson_scale_met_1jet_2016"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"et_boosted1"});
 
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_2jet_2016","CMS_htt_boson_scale_met_2jet_2016"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
@@ -401,7 +401,7 @@ int main(int argc, char **argv)
       //TES Uncertainty                  
       std::cout<<"TES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_scale_t_1prong_2016","CMS_scale_t_3prong_2016","CMS_scale_t_1prong1pizero_2016","CMS_scale_t_3prong1pizero_2016"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.00,
 			  TheFile,CategoryArgs);
@@ -409,7 +409,7 @@ int main(int argc, char **argv)
       // JES
       AddShapesIfNotEmpty({"CMS_JetAbsolute","CMS_JetAbsolute_2016","CMS_JetBBEC1","CMS_JetBBEC1_2016","CMS_JetEC2","CMS_JetEC2_2016",
 	    "CMS_JetFlavorQCD","CMS_JetHF","CMS_JetHF_2016","CMS_JetRelativeBal"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","TTT","VVT","STT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","STL","ZL","TTL","TTT","VVT","STT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.000,
 	TheFile,CategoryArgs);      
@@ -417,7 +417,7 @@ int main(int argc, char **argv)
       //JER
       std::cout<<"JER"<<std::endl;
       AddShapesIfNotEmpty({"CMS_JER_2016"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","WH_htt","ZH_htt","VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.000,
 			  TheFile,CategoryArgs);
@@ -426,7 +426,7 @@ int main(int argc, char **argv)
       //ggH Theory Uncertainties
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
             "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-        JoinStr({ggH_STXS,{"ggH_hww125"}}),
+        JoinStr({ggH_STXS,{"ggH_hww"}}),
         &cb,
         1.00,
         TheFile,CategoryArgs);
@@ -435,14 +435,14 @@ int main(int argc, char **argv)
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
 
       //Electron Energy scale uncertainties
       AddShapesIfNotEmpty({"CMS_scale_e"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
@@ -474,10 +474,10 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_htt_emb_ttbar_2016", "shape", SystMap<>::init(1.00));
 
       //TES uncertainty
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong1pizero_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong1pizero_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong1pizero_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong1pizero_2016", "shape", SystMap<>::init(0.866));
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong_2016", "shape", SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong1pizero_2016", "shape", SystMap<>::init(0.500));
@@ -485,7 +485,7 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_3prong1pizero_2016", "shape", SystMap<>::init(0.500));
 
       //electron energy scale
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_e_2016","shape",SystMap<>::init(0.866));      
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_e_emb_2016","shape",SystMap<>::init(0.866));      
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_e_2016","shape",SystMap<>::init(0.500));      
 

--- a/bin/SMHTT2016_mt.cpp
+++ b/bin/SMHTT2016_mt.cpp
@@ -62,174 +62,174 @@ int main(int argc, char **argv)
   //! [part3]
   cb.AddObservations({"*"}, {"smh2016"}, {"13TeV"}, {"mt"}, cats);
 
-  vector<string> bkg_procs = {"VVT","STT","TTT","jetFakes","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"VVT","STT","TTT","jetFakes","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e")) {bkg_procs.push_back("ZT");}
   else bkg_procs.push_back("embedded");
   if (Input.OptionExists("-dp") || Input.OptionExists("-dn") || Input.OptionExists("-dm"))
     {
-      bkg_procs.push_back("ggH_nonfid_htt125");
-      bkg_procs.push_back("qqH_nonfid_htt125");
-      bkg_procs.push_back("WH_nonfid_htt125");
-      bkg_procs.push_back("ZH_nonfid_htt125");
+      bkg_procs.push_back("ggH_nonfid_htt");
+      bkg_procs.push_back("qqH_nonfid_htt");
+      bkg_procs.push_back("WH_nonfid_htt");
+      bkg_procs.push_back("ZH_nonfid_htt");
     }
   else
     {
-      bkg_procs.push_back("ggH_hww125");
-      bkg_procs.push_back("qqH_hww125");
-      bkg_procs.push_back("WH_hww125");
-      bkg_procs.push_back("ZH_hww125");
+      bkg_procs.push_back("ggH_hww");
+      bkg_procs.push_back("qqH_hww");
+      bkg_procs.push_back("WH_hww");
+      bkg_procs.push_back("ZH_hww");
     }
   cb.AddProcesses({"*"}, {"smh2016"}, {"13TeV"}, {"mt"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
   //PTH differential option
   else if (Input.OptionExists("-dp")) ggH_STXS = {
-      "ggH_PTH_0_20_htt125",
-      "ggH_PTH_20_45_htt125",
-      "ggH_PTH_45_80_htt125",
-      "ggH_PTH_80_120_htt125",
-      "ggH_PTH_120_200_htt125",
-      "ggH_PTH_200_350_htt125",
-      "ggH_PTH_350_600_htt125",
-      "ggH_PTH_GE600_htt125",
+      "ggH_PTH_0_20_htt",
+      "ggH_PTH_20_45_htt",
+      "ggH_PTH_45_80_htt",
+      "ggH_PTH_80_120_htt",
+      "ggH_PTH_120_200_htt",
+      "ggH_PTH_200_350_htt",
+      "ggH_PTH_350_600_htt",
+      "ggH_PTH_GE600_htt",
     };
   //NJets differential Option
   else if (Input.OptionExists("-dn")) ggH_STXS = {
-      "ggH_NJETS_0_htt125",
-      "ggH_NJETS_1_htt125",
-      "ggH_NJETS_2_htt125",
-      "ggH_NJETS_GE3_htt125",
+      "ggH_NJETS_0_htt",
+      "ggH_NJETS_1_htt",
+      "ggH_NJETS_2_htt",
+      "ggH_NJETS_GE3_htt",
     };
   //mjj differential option
   else if (Input.OptionExists("-dm")) ggH_STXS = {
-      "ggH_MJJ_0_150_htt125",
-      "ggH_150_300_htt125",
-      "ggH_300_450_htt125",
-      "ggH_450_600_htt125",
-      "ggH_600_1000_htt125",
-      "ggH_1000_1400_htt125",
-      "ggH_1400_1800_htt125",
-      "ggH_GE1800_htt125",
+      "ggH_MJJ_0_150_htt",
+      "ggH_150_300_htt",
+      "ggH_300_450_htt",
+      "ggH_450_600_htt",
+      "ggH_600_1000_htt",
+      "ggH_1000_1400_htt",
+      "ggH_1400_1800_htt",
+      "ggH_GE1800_htt",
     };
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
   else if (Input.OptionExists("-dp")) qqH_STXS = {
-      "qqH_PTH_0_20_htt125",
-      "qqH_PTH_20_45_htt125",
-      "qqH_PTH_45_80_htt125",
-      "qqH_PTH_80_120_htt125",
-      "qqH_PTH_120_200_htt125",
-      "qqH_PTH_200_350_htt125",
-      "qqH_PTH_350_600_htt125",
-      "qqH_PTH_GE600_htt125",
+      "qqH_PTH_0_20_htt",
+      "qqH_PTH_20_45_htt",
+      "qqH_PTH_45_80_htt",
+      "qqH_PTH_80_120_htt",
+      "qqH_PTH_120_200_htt",
+      "qqH_PTH_200_350_htt",
+      "qqH_PTH_350_600_htt",
+      "qqH_PTH_GE600_htt",
     };
   //NJets differential Option
   else if (Input.OptionExists("-dn")) qqH_STXS = {
-      "qqH_NJETS_0_htt125",
-      "qqH_NJETS_1_htt125",
-      "qqH_NJETS_2_htt125",
-      "qqH_NJETS_GE3_htt125",
+      "qqH_NJETS_0_htt",
+      "qqH_NJETS_1_htt",
+      "qqH_NJETS_2_htt",
+      "qqH_NJETS_GE3_htt",
     };
   //mjj differential option
   else if (Input.OptionExists("-dm")) qqH_STXS = {
-      "qqH_MJJ_0_150_htt125",
-      "qqH_150_300_htt125",
-      "qqH_300_450_htt125",
-      "qqH_450_600_htt125",
-      "qqH_600_1000_htt125",
-      "qqH_1000_1400_htt125",
-      "qqH_1400_1800_htt125",
-      "qqH_GE1800_htt125",
+      "qqH_MJJ_0_150_htt",
+      "qqH_150_300_htt",
+      "qqH_300_450_htt",
+      "qqH_450_600_htt",
+      "qqH_600_1000_htt",
+      "qqH_1000_1400_htt",
+      "qqH_1400_1800_htt",
+      "qqH_GE1800_htt",
     };
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> WH_STXS = {"WH_htt125"};
+  vector<string> WH_STXS = {"WH_htt"};
   if (Input.OptionExists("-dp")) WH_STXS = {
-      "WH_PTH_0_20_htt125",
-      "WH_PTH_20_45_htt125",
-      "WH_PTH_45_80_htt125",
-      "WH_PTH_80_120_htt125",
-      "WH_PTH_120_200_htt125",
-      "WH_PTH_200_350_htt125",
-      "WH_PTH_350_600_htt125",
-      "WH_PTH_GE600_htt125",
+      "WH_PTH_0_20_htt",
+      "WH_PTH_20_45_htt",
+      "WH_PTH_45_80_htt",
+      "WH_PTH_80_120_htt",
+      "WH_PTH_120_200_htt",
+      "WH_PTH_200_350_htt",
+      "WH_PTH_350_600_htt",
+      "WH_PTH_GE600_htt",
     };
   //NJets differential Option
   else if (Input.OptionExists("-dn")) WH_STXS = {
-      "WH_NJETS_0_htt125",
-      "WH_NJETS_1_htt125",
-      "WH_NJETS_2_htt125",
-      "WH_NJETS_GE3_htt125",
+      "WH_NJETS_0_htt",
+      "WH_NJETS_1_htt",
+      "WH_NJETS_2_htt",
+      "WH_NJETS_GE3_htt",
     };
   //mjj differential option
   else if (Input.OptionExists("-dm")) WH_STXS = {
-      "WH_MJJ_0_150_htt125",
-      "WH_150_300_htt125",
-      "WH_300_450_htt125",
-      "WH_450_600_htt125",
-      "WH_600_1000_htt125",
-      "WH_1000_1400_htt125",
-      "WH_1400_1800_htt125",
-      "WH_GE1800_htt125",
+      "WH_MJJ_0_150_htt",
+      "WH_150_300_htt",
+      "WH_300_450_htt",
+      "WH_450_600_htt",
+      "WH_600_1000_htt",
+      "WH_1000_1400_htt",
+      "WH_1400_1800_htt",
+      "WH_GE1800_htt",
     };
 
-  vector<string> ZH_STXS = {"ZH_htt125"};
+  vector<string> ZH_STXS = {"ZH_htt"};
   if (Input.OptionExists("-dp")) ZH_STXS = {
-      "ZH_PTH_0_20_htt125",
-      "ZH_PTH_20_45_htt125",
-      "ZH_PTH_45_80_htt125",
-      "ZH_PTH_80_120_htt125",
-      "ZH_PTH_120_200_htt125",
-      "ZH_PTH_200_350_htt125",
-      "ZH_PTH_350_600_htt125",
-      "ZH_PTH_GE600_htt125",
+      "ZH_PTH_0_20_htt",
+      "ZH_PTH_20_45_htt",
+      "ZH_PTH_45_80_htt",
+      "ZH_PTH_80_120_htt",
+      "ZH_PTH_120_200_htt",
+      "ZH_PTH_200_350_htt",
+      "ZH_PTH_350_600_htt",
+      "ZH_PTH_GE600_htt",
     };
   //NJets differential Option
   else if (Input.OptionExists("-dn")) ZH_STXS = {
-      "ZH_NJETS_0_htt125",
-      "ZH_NJETS_1_htt125",
-      "ZH_NJETS_2_htt125",
-      "ZH_NJETS_GE3_htt125",
+      "ZH_NJETS_0_htt",
+      "ZH_NJETS_1_htt",
+      "ZH_NJETS_2_htt",
+      "ZH_NJETS_GE3_htt",
     };
   //mjj differential option
   else if (Input.OptionExists("-dm")) ZH_STXS = {
-      "ZH_MJJ_0_150_htt125",
-      "ZH_150_300_htt125",
-      "ZH_300_450_htt125",
-      "ZH_450_600_htt125",
-      "ZH_600_1000_htt125",
-      "ZH_1000_1400_htt125",
-      "ZH_1400_1800_htt125",
-      "ZH_GE1800_htt125",
+      "ZH_MJJ_0_150_htt",
+      "ZH_150_300_htt",
+      "ZH_300_450_htt",
+      "ZH_450_600_htt",
+      "ZH_600_1000_htt",
+      "ZH_1000_1400_htt",
+      "ZH_1400_1800_htt",
+      "ZH_GE1800_htt",
     };
   
   vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,WH_STXS,ZH_STXS});
@@ -251,23 +251,23 @@ int main(int argc, char **argv)
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process(JoinStr({WH_STXS,{"WH_hww125"}})).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process(JoinStr({ZH_STXS,{"ZH_hww125"}})).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
-  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({WH_STXS,{"WH_hww125"}})).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process(JoinStr({ZH_STXS,{"ZH_hww125"}})).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process(JoinStr({WH_STXS,{"WH_hww"}})).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process(JoinStr({ZH_STXS,{"ZH_hww"}})).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({WH_STXS,{"WH_hww"}})).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process(JoinStr({ZH_STXS,{"ZH_hww"}})).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
   
   //Muon ID efficiency: Decorollated in 18-032 datacards.  
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_m_2016","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_m_2016","lnN",SystMap<>::init(1.02));
 
   // Against ele and against mu for real taus
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_t_againstemu_mt_2016","lnN",SystMap<>::init(1.01));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_t_againstemu_mt_2016","lnN",SystMap<>::init(1.01));
 
   // b-tagging efficiency: 5% in ttbar and 0.5% otherwise.
   cb.cp().process({"TTT","TTL","STL","STT"}).AddSyst(cb,"CMS_htt_eff_b_TT_2016","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2016","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2016","lnN",SystMap<>::init(1.005));
 
   // XSection Uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -276,14 +276,14 @@ int main(int argc, char **argv)
   cb.cp().process({"ZT","ZL"}).AddSyst(cb,"CMS_htt_zjXsec", "lnN", SystMap<>::init(1.02));
 
   //Muon Fake Rate Uncertainty
-  cb.cp().process({"ZL","TTL","VVL"}).AddSyst(cb, "CMS_mFakeTau_2016 ", "lnN",SystMap<>::init(1.20));    
+  cb.cp().process({"ZL","TTL","VVL"}).AddSyst(cb, "CMS_fake_m_2016 ", "lnN",SystMap<>::init(1.20));    
   
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2016", "lnN", SystMap<>::init(1.022));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.009));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_13TeV_2016", "lnN", SystMap<>::init(1.022));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.009));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.004));
 
   cb.cp().process({"jetFakes"}).bin({"mt_0jet_PTH_0_10"}).AddSyst(cb,"CMS_jetFakesNorm_0jetlow_mt_2016","lnN",SystMap<>::init(1.05));
   cb.cp().process({"jetFakes"}).bin({"mt_0jet_PTH_GE10"}).AddSyst(cb,"CMS_jetFakesNorm_0jethigh_mt_2016","lnN",SystMap<>::init(1.05));
@@ -310,25 +310,25 @@ int main(int argc, char **argv)
       TopVector = {"TTL","TTT"};
       if(Input.OptionExists("-e"))
 	{	  
-	  RecoilVector = JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}});
+	  RecoilVector = JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}});
 	  ZPTVector = {"ZT","ZL"};	  
-	  TESVector = JoinStr({sig_procs,{"VVT","STT","ZT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  JESVector = JoinStr({sig_procs,{"ZT","VVT","STT","TTT","VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  MuESVector = JoinStr({sig_procs,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  PrefiringVector = JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  TauIDVector = JoinStr({sig_procs,{"VVT","STT","ZT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  TriggerVector = JoinStr({sig_procs,{"VVT","STT","ZT","TTT","VVL","STL","TTL","ZL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
+	  TESVector = JoinStr({sig_procs,{"VVT","STT","ZT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  JESVector = JoinStr({sig_procs,{"ZT","VVT","STT","TTT","VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  MuESVector = JoinStr({sig_procs,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  PrefiringVector = JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  TauIDVector = JoinStr({sig_procs,{"VVT","STT","ZT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  TriggerVector = JoinStr({sig_procs,{"VVT","STT","ZT","TTT","VVL","STL","TTL","ZL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
 	}
       else
 	{	  
-	  RecoilVector = JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}});
+	  RecoilVector = JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}});
 	  ZPTVector = {"ZL"};	  
-	  TESVector = JoinStr({sig_procs,{"VVT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  JESVector = JoinStr({sig_procs,{"VVT","TTT","VVL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  MuESVector = JoinStr({sig_procs,{"ZL","VVT","TTT","VVL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});	  
-	  PrefiringVector = JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  TauIDVector = JoinStr({sig_procs,{"VVT","STT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  TriggerVector = JoinStr({sig_procs,{"VVT","STT","TTT","VVL","STL","TTL","ZL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
+	  TESVector = JoinStr({sig_procs,{"VVT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  JESVector = JoinStr({sig_procs,{"VVT","TTT","VVL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  MuESVector = JoinStr({sig_procs,{"ZL","VVT","TTT","VVL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});	  
+	  PrefiringVector = JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  TauIDVector = JoinStr({sig_procs,{"VVT","STT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  TriggerVector = JoinStr({sig_procs,{"VVT","STT","TTT","VVL","STL","TTL","ZL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
 	}
       
 
@@ -573,7 +573,7 @@ int main(int argc, char **argv)
       std::cout<<"ggH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
 	    "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-	JoinStr({ggH_STXS,{"ggH_hww125"}}),
+	JoinStr({ggH_STXS,{"ggH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);            
@@ -582,7 +582,7 @@ int main(int argc, char **argv)
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
@@ -619,10 +619,10 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_htt_emb_ttbar_2016", "shape", SystMap<>::init(1.00));
 
       //TES uncertainty
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong1pizero_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong1pizero_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong1pizero_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong1pizero_2016", "shape", SystMap<>::init(0.866));
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong_2016", "shape", SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong1pizero_2016", "shape", SystMap<>::init(0.500));
@@ -637,9 +637,9 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_mutautrg_2016","shape",SystMap<>::init(0.500));
       
       //MuonES uncertaity
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_etalt1p2_2016","shape",SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_eta1p2to2p1_2016","shape",SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_eta2p1to2p4_2016","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_etalt1p2_2016","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_eta1p2to2p1_2016","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_eta2p1to2p4_2016","shape",SystMap<>::init(0.866));
       
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_etalt1p2_2016","shape",SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_eta1p2to2p1_2016","shape",SystMap<>::init(0.500));

--- a/bin/SMHTT2016_tt.cpp
+++ b/bin/SMHTT2016_tt.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
   //! [part3]
   cb.AddObservations({"*"}, {"smh2016"}, {"13TeV"}, {"tt"}, cats);
 
-  vector<string> bkg_procs = {"embedded","jetFakes","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"embedded","jetFakes","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e")) { // disable embed
     bkg_procs.erase(std::remove(bkg_procs.begin(), bkg_procs.end(), "embedded"), bkg_procs.end());
     bkg_procs.push_back("ZT");
@@ -70,40 +70,40 @@ int main(int argc, char **argv)
   cb.AddProcesses({"*"}, {"smh2016"}, {"13TeV"}, {"tt"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125"}});
+  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt"}});
   cb.AddProcesses(masses, {"smh2016"}, {"13TeV"}, {"tt"}, sig_procs, cats, true);
 
   //! [part4]
@@ -122,19 +122,19 @@ int main(int argc, char **argv)
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
   //cb.cp().process(qqH_STXS).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qqbar", "lnN", SystMap<>::init(1.021));
   
   
   // b-tagging efficiency: Changed into lnN.
   //5% in ttbar and 0.5% otherwise.
   cb.cp().process({"TTT","TTL","STT","STL"}).AddSyst(cb,"CMS_htt_eff_b_TTL","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b","lnN",SystMap<>::init(1.005));
 
   // XSection Uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -143,11 +143,11 @@ int main(int argc, char **argv)
   cb.cp().process({"ZT","ZL"}).AddSyst(cb,"CMS_htt_zjXsec", "lnN", SystMap<>::init(1.02));
   
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2016", "lnN", SystMap<>::init(1.022));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.009));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_13TeV_2016", "lnN", SystMap<>::init(1.022));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.009));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.004));
 
   cb.cp().process({"jetFakes"}).bin({"tt_0jet"}).AddSyst(cb,"CMS_jetFakesNorm_0jet_tt_2016","lnN",SystMap<>::init(1.05));
 
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
 
       // Prefiring
       AddShapesIfNotEmpty({"CMS_prefiring"},
-                          JoinStr({sig_procs,{"VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({sig_procs,{"VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
       // Tau ID eff in DM bins
       std::cout<<"Tau ID eff"<<std::endl;
       AddShapesIfNotEmpty({"CMS_tauideff_dm0_2016","CMS_tauideff_dm1_2016","CMS_tauideff_dm10_2016","CMS_tauideff_dm11_2016"},
-                          JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
       // Trg eff. 
       std::cout<<"Trigger eff"<<std::endl;
       AddShapesIfNotEmpty({"CMS_doubletautrg_dm0_2016","CMS_doubletautrg_dm1_2016","CMS_doubletautrg_dm10_2016","CMS_doubletautrg_dm11_2016"},
-                          JoinStr({ggH_STXS,qqH_STXS,{"VVL","STL","TTL","ZL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({ggH_STXS,qqH_STXS,{"VVL","STL","TTL","ZL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2016","CMS_htt_boson_scale_met_0jet_2016",
 		"CMS_htt_boson_reso_met_1jet_2016","CMS_htt_boson_scale_met_1jet_2016",
 		"CMS_htt_boson_reso_met_2jet_2016","CMS_htt_boson_scale_met_2jet_2016"},
-	    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}}),
+	    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}}),
 	    &cb,
 	    1.00,
 	    TheFile,CategoryArgs);
@@ -253,21 +253,21 @@ int main(int argc, char **argv)
       else {
 	std::cout<<"Recoil shapes"<<std::endl;
 	AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2016","CMS_htt_boson_scale_met_0jet_2016"},
-			    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}}),
+			    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}}),
 			    &cb,
 			    1.00,
 			    TheFile,
 			    {"tt_0jet"});
 	
 	AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_1jet_2016","CMS_htt_boson_scale_met_1jet_2016"},
-			    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}}),
+			    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}}),
 			    &cb,
 			    1.00,
 			    TheFile,
 			    {"tt_boosted_onejet"});
 	
 	AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_2jet_2016","CMS_htt_boson_scale_met_2jet_2016"},
-			    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}}),
+			    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}}),
 			    &cb,
 			    1.00,
 			    TheFile,
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
       //TES Uncertainty                  
       std::cout<<"TES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_scale_t_1prong_2016","CMS_scale_t_3prong_2016","CMS_scale_t_1prong1pizero_2016","CMS_scale_t_3prong1pizero_2016"},
-                          JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
       std::cout<<"JES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_JetAbsolute","CMS_JetAbsolute_2016","CMS_JetBBEC1","CMS_JetBBEC1_2016","CMS_JetEC2","CMS_JetEC2_2016",
 	    "CMS_JetFlavorQCD","CMS_JetHF","CMS_JetHF_2016","CMS_JetRelativeBal"},
-	JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt","VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.000,
 	TheFile,CategoryArgs);
@@ -312,7 +312,7 @@ int main(int argc, char **argv)
       //JER
       std::cout<<"JER"<<std::endl;
       AddShapesIfNotEmpty({"CMS_JER_2016"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt","VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.000,
 			  TheFile,CategoryArgs);
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
       std::cout<<"ggH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
             "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-	JoinStr({ggH_STXS,{"ggH_hww125"}}),
+	JoinStr({ggH_STXS,{"ggH_hww"}}),
         &cb,
         1.00,
         TheFile,CategoryArgs);
@@ -331,7 +331,7 @@ int main(int argc, char **argv)
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
@@ -356,10 +356,10 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_htt_emb_ttbar_2016", "shape", SystMap<>::init(1.00));
 
       //TES uncertainty
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong1pizero_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong_2016", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong1pizero_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong1pizero_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong_2016", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong1pizero_2016", "shape", SystMap<>::init(0.866));
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong_2016", "shape", SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong1pizero_2016", "shape", SystMap<>::init(0.500));

--- a/bin/SMHTT2017_em.cpp
+++ b/bin/SMHTT2017_em.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
   //! [part3]
   cb.AddObservations({"*"}, {"smh2017"}, {"13TeV"}, {"em"}, cats);
 
-  vector<string> bkg_procs = {"W","QCD","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"W","QCD","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e")) 
     {
       bkg_procs.push_back("ZT");      
@@ -70,40 +70,40 @@ int main(int argc, char **argv)
   cb.AddProcesses({"*"}, {"smh2017"}, {"13TeV"}, {"em"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125"}});
+  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt"}});
   cb.AddProcesses(masses, {"smh2017"}, {"13TeV"}, {"em"}, sig_procs, cats, true);
 
   //! [part4]
@@ -121,25 +121,25 @@ int main(int argc, char **argv)
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
-  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qqbar", "lnN", SystMap<>::init(1.021));
   
   //Electron ID efficiency
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_e_2017","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_e_2017","lnN",SystMap<>::init(1.02));
   cb.cp().process({"W"}).AddSyst(cb,"CMS_eff_e_2017","lnN",SystMap<>::init(1.01));
 
   //Muon ID efficiency
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_m_2017","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_m_2017","lnN",SystMap<>::init(1.02));
   cb.cp().process({"W"}).AddSyst(cb,"CMS_eff_m_2017","lnN",SystMap<>::init(1.01));
 
   // b-tagging efficiency: 5% in ttbar and 0.5% otherwise.
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_eff_b_TT_2017","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"ZT","VVT","STT","ZL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2017","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"ZT","VVT","STT","ZL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2017","lnN",SystMap<>::init(1.005));
 
   // XSection Uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -149,16 +149,16 @@ int main(int argc, char **argv)
   cb.cp().process({"W"}).AddSyst(cb,"CMS_htt_jtoellFR_2017", "lnN", SystMap<>::init(1.20));
 
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2017", "lnN", SystMap<>::init(1.020));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.008));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.003));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.003));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.001));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_13TeV_Run2017", "lnN", SystMap<>::init(1.020));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.008));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.003));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.003));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.001));
 
   //Trigger uncertainties
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "CMS_trg_emu_2017", "lnN", SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "CMS_trg_emu_2017", "lnN", SystMap<>::init(1.02));
 
   //********************************************************
   //shape uncertainties
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
       
       // Prefiring
       AddShapesIfNotEmpty({"CMS_prefiring"},
-                          JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -219,21 +219,21 @@ int main(int argc, char **argv)
       else
 	{
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2017","CMS_htt_boson_scale_met_0jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"em_0jetlow","em_0jethigh"});
       
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_1jet_2017","CMS_htt_boson_scale_met_1jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"em_boosted1"});
 
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_2jet_2017","CMS_htt_boson_scale_met_2jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
@@ -260,34 +260,34 @@ int main(int argc, char **argv)
       std::cout<<"JES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_JetAbsolute","CMS_JetAbsolute_2017","CMS_JetBBEC1","CMS_JetBBEC1_2017","CMS_JetEC2","CMS_JetEC2_2017",
 	    "CMS_JetFlavorQCD","CMS_JetHF","CMS_JetHF_2017","CMS_JetRelativeSample_2017","CMS_JetRelativeBal"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.000,
 	TheFile,CategoryArgs);
       /*
       AddShapesIfNotEmpty({"CMS_JetEta3to5_2017","CMS_JetEta0to5_2017","CMS_JetRelativeBal_2017",
 	    "CMS_JetEta0to3_2017"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","STL","ZL","TTL"}}),
 	&cb,
 	0.707,
 	TheFile,CategoryArgs);            
 
       AddShapesIfNotEmpty({"CMS_JetEta3to5","CMS_JetEta0to5","CMS_JetRelativeBal",
             "CMS_JetEta0to3"},
-        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL"}}),
+        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","STL","ZL","TTL"}}),
         &cb,
         0.707,
         TheFile,CategoryArgs);
 
       AddShapesIfNotEmpty({"CMS_JetRelativeSample_2017","CMS_JetEC2_2017"},
-        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL"}}),
+        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","STL","ZL","TTL"}}),
         &cb,
         1.000,
         TheFile,CategoryArgs);
       */
       //JER      
       AddShapesIfNotEmpty({"CMS_JER_2017"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.000,
 			  TheFile,CategoryArgs);
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
       std::cout<<"THU"<<std::endl;
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
 	    "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-	JoinStr({ggH_STXS,{"ggH_hww125"}}),
+	JoinStr({ggH_STXS,{"ggH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);            
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
       //Muon Energy scale uncertainties
       std::cout<<"Muon ES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_scale_m_etalt1p2","CMS_scale_m_eta1p2to2p1","CMS_scale_m_eta2p1to2p4"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
@@ -321,7 +321,7 @@ int main(int argc, char **argv)
       //Electron Energy scale uncertainties
       std::cout<<"Electron ES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_scale_e"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","TTT","ZL","VVL","TTL","STT","STL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","TTT","ZL","VVL","TTL","STT","STL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
         &cb,
         1.00,
         TheFile,CategoryArgs);
@@ -344,16 +344,16 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_htt_emb_ttbar_2017", "shape", SystMap<>::init(1.00));    
 
       //muon energy scale
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_etalt1p2_2017","shape",SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_eta1p2to2p1_2017","shape",SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_eta2p1to2p4_2017","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_etalt1p2_2017","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_eta1p2to2p1_2017","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_eta2p1to2p4_2017","shape",SystMap<>::init(0.866));
       
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_etalt1p2_2017","shape",SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_eta1p2to2p1_2017","shape",SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_eta2p1to2p4_2017","shape",SystMap<>::init(0.500));
 
       //electron energy scale
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_e_2017","shape",SystMap<>::init(0.866));      
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_e_emb_2017","shape",SystMap<>::init(0.866));      
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_e_2017","shape",SystMap<>::init(0.500));      
 

--- a/bin/SMHTT2017_et.cpp
+++ b/bin/SMHTT2017_et.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
   //! [part3]
   cb.AddObservations({"*"}, {"smh2017"}, {"13TeV"}, {"et"}, cats);
 
-  vector<string> bkg_procs = {"VVT","STT","TTT","jetFakes","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"VVT","STT","TTT","jetFakes","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e")) 
     {
       bkg_procs.push_back("ZT");
@@ -67,40 +67,40 @@ int main(int argc, char **argv)
   cb.AddProcesses({"*"}, {"smh2017"}, {"13TeV"}, {"et"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125"}});
+  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt"}});
   cb.AddProcesses(masses, {"smh2017"}, {"13TeV"}, {"et"}, sig_procs, cats, true);
 
   //! [part4]
@@ -116,14 +116,14 @@ int main(int argc, char **argv)
   //*******************************************
   
   //Ele ID efficiency 
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_e_2017","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_e_2017","lnN",SystMap<>::init(1.02));
 
   // Against ele and against mu for real taus
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_t_againstemu_et_2017","lnN",SystMap<>::init(1.01));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_t_againstemu_et_2017","lnN",SystMap<>::init(1.01));
 
   // b-tagging efficiency: 5% in ttbar and 0.5% otherwise.
   cb.cp().process({"TTT","TTL","STL","STT"}).AddSyst(cb,"CMS_htt_eff_b_TT_2017","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2017","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2017","lnN",SystMap<>::init(1.005));
 
   // XS uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -132,29 +132,29 @@ int main(int argc, char **argv)
   cb.cp().process({"ZT","ZL"}).AddSyst(cb,"CMS_htt_zjXsec", "lnN", SystMap<>::init(1.02));
 
   //Electron Fake Rate Uncertainty
-  //cb.cp().process({"ZL","TTL","STL","VVL"}).AddSyst(cb, "CMS_eFakeTau_2017", "lnN",SystMap<>::init(1.15));    
-  cb.cp().process({"TTL","STL","VVL"}).AddSyst(cb, "CMS_eFakeTau_2017", "lnN",SystMap<>::init(1.15));    
+  //cb.cp().process({"ZL","TTL","STL","VVL"}).AddSyst(cb, "CMS_fake_e_2017", "lnN",SystMap<>::init(1.15));    
+  cb.cp().process({"TTL","STL","VVL"}).AddSyst(cb, "CMS_fake_e_2017", "lnN",SystMap<>::init(1.15));    
 
   //theory uncerts
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
-  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qqbar", "lnN", SystMap<>::init(1.021));
 
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2017", "lnN", SystMap<>::init(1.020));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.008));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.003));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.003));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.001));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_13TeV_Run2017", "lnN", SystMap<>::init(1.020));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.008));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.003));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.003));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.001));
 
   cb.cp().process({"jetFakes"}).bin({"et_0jetlow"}).AddSyst(cb,"CMS_jetFakesNorm_0jetlow_et_2017","lnN",SystMap<>::init(1.05));
   cb.cp().process({"jetFakes"}).bin({"et_0jethigh"}).AddSyst(cb,"CMS_jetFakesNorm_0jethigh_et_2017","lnN",SystMap<>::init(1.05));
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
  
       // Prefiring
       AddShapesIfNotEmpty({"CMS_prefiring"},
-                          JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
       // Tau ID eff in pt bins
       std::cout<<"Tau ID eff"<<std::endl;
       AddShapesIfNotEmpty({"CMS_tauideff_pt30to35_2017","CMS_tauideff_pt35to40_2017","CMS_tauideff_ptgt40_2017"},
-                          JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
       // Trg eff. It is a shape because the 2 triggers affect the ele pT spectrum differently
       std::cout<<"Trigger eff"<<std::endl;
       AddShapesIfNotEmpty({"CMS_singleeletrg_2017","CMS_eletautrg_2017"},
-                          JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","VVL","STL","TTL","ZL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","VVL","STL","TTL","ZL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
       // e to tau energy fake scale            
       /*
       std::cout<<"Adding Shapes..."<<std::endl;
-      AddShapesIfNotEmpty({"CMS_scale_efaket_1prong_2017","CMS_scale_efaket_1prong1pizero_2017"},
+      AddShapesIfNotEmpty({"CMS_scale_fake_e_1prong_2017","CMS_scale_fake_e_1prong1pizero_2017"},
 			  {"ZL"},
 			  &cb,
 			  1.00,
@@ -201,18 +201,18 @@ int main(int argc, char **argv)
       */
       
       std::cout<<"ZLShapes"<<std::endl;
-      AddShapesIfNotEmpty({"CMS_scale_efaket_1prong_barrel_2017",
-	    "CMS_scale_efaket_1prong1pizero_barrel_2017",
-	    "CMS_scale_efaket_1prong_endcap_2017",
-	    "CMS_scale_efaket_1prong1pizero_endcap_2017"},
+      AddShapesIfNotEmpty({"CMS_scale_fake_e_1prong_barrel_2017",
+	    "CMS_scale_fake_e_1prong1pizero_barrel_2017",
+	    "CMS_scale_fake_e_1prong_endcap_2017",
+	    "CMS_scale_fake_e_1prong1pizero_endcap_2017"},
 			  {"ZL"},
 			  &cb,
 			  1.00,
 			  TheFile,CategoryArgs);
       
-      AddShapesIfNotEmpty({"CMS_norm_efaket_slice1_2017",
-	    "CMS_norm_efaket_slice2_2017",
-	    "CMS_norm_efaket_slice3_2017"},
+      AddShapesIfNotEmpty({"CMS_norm_fake_e_slice1_2017",
+	    "CMS_norm_fake_e_slice2_2017",
+	    "CMS_norm_fake_e_slice3_2017"},
 			  {"ZL"},
 			  &cb,
 			  1.00,
@@ -392,21 +392,21 @@ int main(int argc, char **argv)
       else 
 	{
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2017","CMS_htt_boson_scale_met_0jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"et_0jetlow","et_0jethigh"});
       
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_1jet_2017","CMS_htt_boson_scale_met_1jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"et_boosted1"});
 
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_2jet_2017","CMS_htt_boson_scale_met_2jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
@@ -429,7 +429,7 @@ int main(int argc, char **argv)
   
       //TES Uncertainty                  
       AddShapesIfNotEmpty({"CMS_scale_t_1prong_2017","CMS_scale_t_3prong_2017","CMS_scale_t_1prong1pizero_2017","CMS_scale_t_3prong1pizero_2017"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.00,
 			  TheFile,CategoryArgs);
@@ -437,26 +437,26 @@ int main(int argc, char **argv)
       // Jet Energy Scale Uncertainties            
       AddShapesIfNotEmpty({"CMS_JetAbsolute","CMS_JetAbsolute_2017","CMS_JetBBEC1","CMS_JetBBEC1_2017","CMS_JetEC2","CMS_JetEC2_2017",
 	    "CMS_JetFlavorQCD","CMS_JetHF","CMS_JetHF_2017","CMS_JetRelativeSample_2017","CMS_JetRelativeBal"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","TTT","VVT","STT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","STL","ZL","TTL","TTT","VVT","STT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.000,
 	TheFile,CategoryArgs);
       /*
       AddShapesIfNotEmpty({"CMS_JetEta3to5_2017","CMS_JetEta0to5_2017","CMS_JetRelativeBal_2017",
 	    "CMS_JetEta0to3_2017"},
-	    JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","VVT","STT"}}),
+	    JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","STL","ZL","TTL","VVT","STT"}}),
 	&cb,
 	0.707,
 	TheFile,CategoryArgs);            
 
       AddShapesIfNotEmpty({"CMS_JetRelativeSample","CMS_JetEC2"},
-        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","VVT","STT"}}),
+        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","STL","ZL","TTL","VVT","STT"}}),
         &cb,
         0.707,
         TheFile,CategoryArgs);
 
       AddShapesIfNotEmpty({"CMS_JetRelativeSample_2017","CMS_JetEC2_2017"},
-        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","VVT","STT"}}),
+        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","STL","ZL","TTL","VVT","STT"}}),
         &cb,
         1.000,
         TheFile,CategoryArgs);
@@ -464,7 +464,7 @@ int main(int argc, char **argv)
 
       //JER      
       AddShapesIfNotEmpty({"CMS_JER_2017"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","WH_htt","ZH_htt","VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.000,
 			  TheFile,CategoryArgs);
@@ -472,7 +472,7 @@ int main(int argc, char **argv)
       //ggH Theory Uncertainties
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
 	    "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-	JoinStr({ggH_STXS,{"ggH_hww125"}}),
+	JoinStr({ggH_STXS,{"ggH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);            
@@ -481,14 +481,14 @@ int main(int argc, char **argv)
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
 
       //Electron Energy scale uncertainties
       AddShapesIfNotEmpty({"CMS_scale_e"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
@@ -519,10 +519,10 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_htt_emb_ttbar_2017", "shape", SystMap<>::init(1.00));    
 
       //TES uncertainty
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong1pizero_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong1pizero_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong1pizero_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong1pizero_2017", "shape", SystMap<>::init(0.866));
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong_2017", "shape", SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong1pizero_2017", "shape", SystMap<>::init(0.500));
@@ -530,7 +530,7 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_3prong1pizero_2017", "shape", SystMap<>::init(0.500));
 
       //electron energy scale
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_e_2017","shape",SystMap<>::init(0.866));      
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_e_emb_2017","shape",SystMap<>::init(0.866));      
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_e_2017","shape",SystMap<>::init(0.500));      
 

--- a/bin/SMHTT2017_mt.cpp
+++ b/bin/SMHTT2017_mt.cpp
@@ -58,47 +58,47 @@ int main(int argc, char **argv)
   //! [part3]
   cb.AddObservations({"*"}, {"smh2017"}, {"13TeV"}, {"mt"}, cats);
 
-  vector<string> bkg_procs = {"VVT","STT","TTT","jetFakes","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"VVT","STT","TTT","jetFakes","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e")) {bkg_procs.push_back("ZT");}
   else bkg_procs.push_back("embedded");
 
   cb.AddProcesses({"*"}, {"smh2017"}, {"13TeV"}, {"mt"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125"}});
+  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt"}});
   cb.AddProcesses(masses, {"smh2017"}, {"13TeV"}, {"mt"}, sig_procs, cats, true);
 
   //! [part4]
@@ -117,23 +117,23 @@ int main(int argc, char **argv)
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
-  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qqbar", "lnN", SystMap<>::init(1.021));
   
   //Muon ID efficiency
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_m_2017","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_m_2017","lnN",SystMap<>::init(1.02));
 
   // Against ele and against mu for real taus
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_t_againstemu_mt_2017","lnN",SystMap<>::init(1.01));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_t_againstemu_mt_2017","lnN",SystMap<>::init(1.01));
 
   // b-tagging efficiency: 5% in ttbar and 0.5% otherwise.
   cb.cp().process({"TTT","TTL","STL","STT"}).AddSyst(cb,"CMS_htt_eff_b_TT_2017","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2017","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2017","lnN",SystMap<>::init(1.005));
 
   // XSection Uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -142,16 +142,16 @@ int main(int argc, char **argv)
   cb.cp().process({"ZT","ZL"}).AddSyst(cb,"CMS_htt_zjXsec", "lnN", SystMap<>::init(1.02));
 
   //Muon Fake Rate Uncertainty
-  cb.cp().process({"ZL","TTL","STL","VVL"}).AddSyst(cb, "CMS_mFakeTau_2017", "lnN",SystMap<>::init(1.20));    
+  cb.cp().process({"ZL","TTL","STL","VVL"}).AddSyst(cb, "CMS_fake_m_2017", "lnN",SystMap<>::init(1.20));    
 
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2017", "lnN", SystMap<>::init(1.020));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.008));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.003));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.003));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.001));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_13TeV_Run2017", "lnN", SystMap<>::init(1.020));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.008));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.003));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.003));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZT","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.001));
 
   cb.cp().process({"jetFakes"}).bin({"mt_0jet_PTH_0_10"}).AddSyst(cb,"CMS_jetFakesNorm_0jetlow_mt_2017","lnN",SystMap<>::init(1.05));
   cb.cp().process({"jetFakes"}).bin({"mt_0jet_PTH_GE10"}).AddSyst(cb,"CMS_jetFakesNorm_0jethigh_mt_2017","lnN",SystMap<>::init(1.05));
@@ -177,25 +177,25 @@ int main(int argc, char **argv)
       TopVector = {"TTL","TTT"};
       if(Input.OptionExists("-e"))
 	{	  
-	  RecoilVector = JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}});
+	  RecoilVector = JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}});
 	  ZPTVector = {"ZT","ZL"};	  
-	  TESVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  JESVector = JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  MuESVector = JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","TTL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  PrefiringVector = JoinStr({sig_procs,{"VVL","STL","VVT","STT","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  TauIDVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  TriggerVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","VVL","STL","TTL","ZL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
+	  TESVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  JESVector = JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","WH_htt","ZH_htt","VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  MuESVector = JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","TTL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  PrefiringVector = JoinStr({sig_procs,{"VVL","STL","VVT","STT","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  TauIDVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  TriggerVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","ZT","TTT","VVL","STL","TTL","ZL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
 	}
       else
 	{	  
-	  RecoilVector = JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}});
+	  RecoilVector = JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}});
 	  ZPTVector = {"ZL"};	  
-	  TESVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","TTT","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  JESVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","TTT","WH_htt125","ZH_htt125","VVL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  MuESVector = JoinStr({ggH_STXS,qqH_STXS,{"ZL","VVT","STT","TTT","VVL","STL","TTL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  PrefiringVector = JoinStr({sig_procs,{"VVL","STL","VVT","STT","ZL","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  TauIDVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","TTT","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
-	  TriggerVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","TTT","VVL","STL","TTL","ZL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}});
+	  TESVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","TTT","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  JESVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","TTT","WH_htt","ZH_htt","VVL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  MuESVector = JoinStr({ggH_STXS,qqH_STXS,{"ZL","VVT","STT","TTT","VVL","STL","TTL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  PrefiringVector = JoinStr({sig_procs,{"VVL","STL","VVT","STT","ZL","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  TauIDVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","TTT","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
+	  TriggerVector = JoinStr({ggH_STXS,qqH_STXS,{"VVT","STT","TTT","VVL","STL","TTL","ZL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}});
 	}
 
       // Prefiring
@@ -460,7 +460,7 @@ int main(int argc, char **argv)
       std::cout<<"ggH theory uncerts"<<std::endl;
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
 	    "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-	JoinStr({ggH_STXS,{"ggH_hww125"}}),
+	JoinStr({ggH_STXS,{"ggH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);            
@@ -469,7 +469,7 @@ int main(int argc, char **argv)
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
@@ -509,10 +509,10 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_htt_emb_ttbar_2017", "shape", SystMap<>::init(1.00));    
 
       //TES uncertainty
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong1pizero_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong1pizero_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong1pizero_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong1pizero_2017", "shape", SystMap<>::init(0.866));
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong_2017", "shape", SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong1pizero_2017", "shape", SystMap<>::init(0.500));
@@ -527,9 +527,9 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_mutautrg_2017","shape",SystMap<>::init(0.500));
 
       //MuonES uncertaity
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_etalt1p2_2017","shape",SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_eta1p2to2p1_2017","shape",SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_m_eta2p1to2p4_2017","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_etalt1p2_2017","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_eta1p2to2p1_2017","shape",SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_emb_eta2p1to2p4_2017","shape",SystMap<>::init(0.866));
       
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_etalt1p2_2017","shape",SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_m_eta1p2to2p1_2017","shape",SystMap<>::init(0.500));

--- a/bin/SMHTT2017_tt.cpp
+++ b/bin/SMHTT2017_tt.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
   cb.AddObservations({"*"}, {"smh2017"}, {"13TeV"}, {"tt"}, cats);
 
   
-  vector<string> bkg_procs = {"embedded","jetFakes","ZL","VVL","STL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"embedded","jetFakes","ZL","VVL","STL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e")) { // disable embed
     bkg_procs.erase(std::remove(bkg_procs.begin(), bkg_procs.end(), "embedded"), bkg_procs.end());
     bkg_procs.push_back("ZT");
@@ -70,40 +70,40 @@ int main(int argc, char **argv)
   cb.AddProcesses({"*"}, {"smh2017"}, {"13TeV"}, {"tt"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125"}});
+  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt"}});
   cb.AddProcesses(masses, {"smh2017"}, {"13TeV"}, {"tt"}, sig_procs, cats, true);
 
   //! [part4]
@@ -121,18 +121,18 @@ int main(int argc, char **argv)
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
   //cb.cp().process(qqH_STXS).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qqbar", "lnN", SystMap<>::init(1.021));
 
   // b-tagging efficiency: Changed into lnN.
   //5% in ttbar and 0.5% otherwise.
   cb.cp().process({"TTT","TTL","STT","STL"}).AddSyst(cb,"CMS_htt_eff_b_TTL","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b","lnN",SystMap<>::init(1.005));
 
   // XSection Uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -142,13 +142,13 @@ int main(int argc, char **argv)
   
   
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2017", "lnN", SystMap<>::init(1.020));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.008));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.003));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.003));
-  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.001));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_13TeV_Run2017", "lnN", SystMap<>::init(1.020));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.008));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.003));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamBeamDeflection", "lnN", SystMap<>::init(1.004));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_dynamicBeta", "lnN", SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.003));
+  cb.cp().process(JoinStr({sig_procs,{"VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_ghostsAndSatellites", "lnN", SystMap<>::init(1.001));
 
   cb.cp().process({"jetFakes"}).bin({"tt_0jet"}).AddSyst(cb,"CMS_jetFakesNorm_0jet_tt_2017","lnN",SystMap<>::init(1.05));
 
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
 
       // Prefiring
       AddShapesIfNotEmpty({"CMS_prefiring"},
-                          JoinStr({sig_procs,{"VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({sig_procs,{"VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
       // Tau ID eff in DM bins
       std::cout<<"Tau ID eff"<<std::endl;
       AddShapesIfNotEmpty({"CMS_tauideff_dm0_2017","CMS_tauideff_dm1_2017","CMS_tauideff_dm10_2017","CMS_tauideff_dm11_2017"},
-                          JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
 
       std::cout<<"Trigger eff"<<std::endl;
       AddShapesIfNotEmpty({"CMS_doubletautrg_dm0_2017","CMS_doubletautrg_dm1_2017","CMS_doubletautrg_dm10_2017","CMS_doubletautrg_dm11_2017"},
-                          JoinStr({ggH_STXS,qqH_STXS,{"VVL","STL","TTL","ZL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({ggH_STXS,qqH_STXS,{"VVL","STL","TTL","ZL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -246,7 +246,7 @@ int main(int argc, char **argv)
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2017","CMS_htt_boson_scale_met_0jet_2017",
 		"CMS_htt_boson_reso_met_1jet_2017","CMS_htt_boson_scale_met_1jet_2017",
 		"CMS_htt_boson_reso_met_2jet_2017","CMS_htt_boson_scale_met_2jet_2017"},
-	    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}}),
+	    JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}}),
 	    &cb,
 	    1.00,
 	    TheFile,CategoryArgs);
@@ -254,21 +254,21 @@ int main(int argc, char **argv)
       else
 	{
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2017","CMS_htt_boson_scale_met_0jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"tt_0jet"});
       
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_1jet_2017","CMS_htt_boson_scale_met_1jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"tt_boosted_onejet"});
 
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_2jet_2017","CMS_htt_boson_scale_met_2jet_2017"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
       //TES Uncertainty                  
       std::cout<<"TES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_scale_t_1prong_2017","CMS_scale_t_3prong_2017","CMS_scale_t_1prong1pizero_2017","CMS_scale_t_3prong1pizero_2017"},
-                          JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+                          JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
                           &cb,
                           1.00,
                           TheFile,CategoryArgs);
@@ -302,14 +302,14 @@ int main(int argc, char **argv)
       std::cout<<"JES"<<std::endl;
       AddShapesIfNotEmpty({"CMS_JetAbsolute","CMS_JetAbsolute_2017","CMS_JetBBEC1","CMS_JetBBEC1_2017","CMS_JetEC2","CMS_JetEC2_2017",
 	    "CMS_JetFlavorQCD","CMS_JetHF","CMS_JetHF_2017","CMS_JetRelativeSample_2017","CMS_JetRelativeBal"},
-	JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt","VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.000,
 	TheFile,CategoryArgs);
 
       //JER      
       AddShapesIfNotEmpty({"CMS_JER_2017"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"WH_htt125","ZH_htt125","VVL","STL","ZL","TTL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"WH_htt","ZH_htt","VVL","STL","ZL","TTL","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.000,
 			  TheFile,CategoryArgs);
@@ -317,7 +317,7 @@ int main(int argc, char **argv)
       std::cout<<"ggH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
             "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-	JoinStr({ggH_STXS,{"ggH_hww125"}}),
+	JoinStr({ggH_STXS,{"ggH_hww"}}),
         &cb,
         1.00,
         TheFile,CategoryArgs);
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
@@ -357,10 +357,10 @@ int main(int argc, char **argv)
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_htt_emb_ttbar_2017", "shape", SystMap<>::init(1.00));
 
       //TES uncertainty
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_1prong1pizero_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong_2017", "shape", SystMap<>::init(0.866));
-      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_emb_t_3prong1pizero_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_1prong1pizero_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong_2017", "shape", SystMap<>::init(0.866));
+      cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_emb_3prong1pizero_2017", "shape", SystMap<>::init(0.866));
 
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong_2017", "shape", SystMap<>::init(0.500));
       cb.cp().process({"embedded"}).AddSyst(cb,"CMS_scale_t_1prong1pizero_2017", "shape", SystMap<>::init(0.500));

--- a/bin/SMHTT2018_em.cpp
+++ b/bin/SMHTT2018_em.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
   //! [part3]
   cb.AddObservations({"*"}, {"smh2018"}, {"13TeV"}, {"em"}, cats);
 
-  vector<string> bkg_procs = {"QCD","ZL","VVL","STL","TTL","W","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"};
+  vector<string> bkg_procs = {"QCD","ZL","VVL","STL","TTL","W","ggH_hww","qqH_hww","WH_hww","ZH_hww"};
   if(Input.OptionExists("-e")) 
     {
       bkg_procs.push_back("ZT");      
@@ -71,40 +71,40 @@ int main(int argc, char **argv) {
   cb.AddProcesses({"*"}, {"smh2018"}, {"13TeV"}, {"em"}, bkg_procs, cats, false);
 
   vector<string> ggH_STXS;
-  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt125"};
-  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt125",
-		   "ggH_PTH_0_200_0J_PTH_0_10_htt125",
-		   "ggH_PTH_0_200_1J_PTH_0_60_htt125",
-		   "ggH_PTH_0_200_1J_PTH_60_120_htt125",
-		   "ggH_PTH_0_200_1J_PTH_120_200_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt125",		   
-		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt125",		   
-		   "ggH_FWDH_htt125",
-		   "ggH_PTH_200_300_htt125",
-		   "ggH_PTH_300_450_htt125",
-		   "ggH_PTH_450_650_htt125",
-		   "ggH_PTH_GE650_htt125"};
+  if (Input.OptionExists("-g")) ggH_STXS = {"ggH_htt"};
+  else ggH_STXS = {"ggH_PTH_0_200_0J_PTH_10_200_htt",
+		   "ggH_PTH_0_200_0J_PTH_0_10_htt",
+		   "ggH_PTH_0_200_1J_PTH_0_60_htt",
+		   "ggH_PTH_0_200_1J_PTH_60_120_htt",
+		   "ggH_PTH_0_200_1J_PTH_120_200_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_0_60_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_60_120_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_0_350_PTH_120_200_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_350_700_PTHJJ_GE25_htt",
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_0_25_htt",		   
+		   "ggH_PTH_0_200_GE2J_MJJ_GE700_PTHJJ_GE25_htt",		   
+		   "ggH_FWDH_htt",
+		   "ggH_PTH_200_300_htt",
+		   "ggH_PTH_300_450_htt",
+		   "ggH_PTH_450_650_htt",
+		   "ggH_PTH_GE650_htt"};
   
   vector<string> qqH_STXS; 
-  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt125"};
-  else qqH_STXS = {"qqH_0J_htt125",
-		   "qqH_1J_htt125",
-		   "qqH_GE2J_MJJ_0_60_htt125",
-		   "qqH_GE2J_MJJ_60_120_htt125",
-		   "qqH_GE2J_MJJ_120_350_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt125",
-		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt125",
-		   "qqH_FWDH_htt125"};
+  if(Input.OptionExists("-q")) qqH_STXS = {"qqH_htt"};
+  else qqH_STXS = {"qqH_0J_htt",
+		   "qqH_1J_htt",
+		   "qqH_GE2J_MJJ_0_60_htt",
+		   "qqH_GE2J_MJJ_60_120_htt",
+		   "qqH_GE2J_MJJ_120_350_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_350_700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_0_25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_0_200_MJJ_GE700_PTHJJ_GE25_htt",
+		   "qqH_GE2J_MJJ_GE350_PTH_GE200_htt",
+		   "qqH_FWDH_htt"};
 
-  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"ZH_htt125","WH_htt125"}});
+  vector<string> sig_procs = ch::JoinStr({ggH_STXS,qqH_STXS,{"ZH_htt","WH_htt"}});
   
   cb.AddProcesses(masses, {"smh2018"}, {"13TeV"}, {"em"}, sig_procs, cats, true);    
 
@@ -126,25 +126,25 @@ int main(int argc, char **argv) {
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
   cb.cp().process(sig_procs).AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));  
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
-  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
-  cb.cp().process({"WH_htt125","WH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
-  cb.cp().process({"ZH_htt125","ZH_hww125"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
-  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww125"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww125"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.008));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "QCDScale_VH", "lnN", SystMap<>::init(1.009));
+  //cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.005));
+  cb.cp().process({"WH_htt","WH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.018));
+  cb.cp().process({"ZH_htt","ZH_hww"}).AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.013));
+  cb.cp().process(JoinStr({ggH_STXS,{"ggH_hww"}})).AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp().process(JoinStr({qqH_STXS,{"qqH_hww"}})).AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
   
   //Muon ID efficiency
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_m_2018","lnN",SystMap<>::init(1.02));  
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_m_2018","lnN",SystMap<>::init(1.02));  
   cb.cp().process({"W"}).AddSyst(cb,"CMS_eff_m_2018","lnN",SystMap<>::init(1.01));
 
   //Electron ID efficiency
-  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_eff_e_2018","lnN",SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({{"ZT","TTT","VVT","STT","ZL","TTL","VVL","STL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_eff_e_2018","lnN",SystMap<>::init(1.02));
   cb.cp().process({"W"}).AddSyst(cb,"CMS_eff_e_2018","lnN",SystMap<>::init(1.01));
 
   // b-tagging efficiency: 5% in ttbar and 0.5% otherwise.
   cb.cp().process({"TTT","TTL","STT","STL"}).AddSyst(cb,"CMS_htt_eff_b_TT_2018","lnN",SystMap<>::init(1.05));
-  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2018","lnN",SystMap<>::init(1.005));
+  cb.cp().process(JoinStr({{"ZT","VVT","ZL","VVL","ggH_hww","qqH_hww","WH_hww","ZH_hww"},sig_procs})).AddSyst(cb,"CMS_htt_eff_b_2018","lnN",SystMap<>::init(1.005));
 
   // XSection Uncertainties
   cb.cp().process({"TTT","TTL"}).AddSyst(cb,"CMS_htt_tjXsec", "lnN", SystMap<>::init(1.042));
@@ -156,13 +156,13 @@ int main(int argc, char **argv) {
   cb.cp().process({"W"}).AddSyst(cb,"CMS_htt_jtoellFR_2018", "lnN", SystMap<>::init(1.20));
   
   //Luminosity Uncertainty
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_Run2018", "lnN", SystMap<>::init(1.015));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.020));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.002));
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.002));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_Run2018", "lnN", SystMap<>::init(1.015));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_XYfactorization", "lnN", SystMap<>::init(1.020));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_lengthScale", "lnN", SystMap<>::init(1.002));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "lumi_beamCurrentCalibration", "lnN", SystMap<>::init(1.002));
 
   //Trigger uncertainties
-  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}})).AddSyst(cb, "CMS_trg_emu_2018", "lnN", SystMap<>::init(1.02));
+  cb.cp().process(JoinStr({sig_procs,{"W","VVL","VVT","STT","STL","ZL","ZT","TTL","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}})).AddSyst(cb, "CMS_trg_emu_2018", "lnN", SystMap<>::init(1.02));
 
   //*************************************************************
   //shape uncertainties
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2018","CMS_htt_boson_scale_met_0jet_2018",
 		"CMS_htt_boson_reso_met_1jet_2018","CMS_htt_boson_scale_met_1jet_2018",
 		"CMS_htt_boson_reso_met_2jet_2018","CMS_htt_boson_scale_met_2jet_2018"},
-	    JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","WH_htt125","ZH_htt125"}}),
+	    JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","WH_htt","ZH_htt"}}),
 	    &cb,
 	    1.00,
 	    TheFile,CategoryArgs);
@@ -216,21 +216,21 @@ int main(int argc, char **argv) {
       else
 	{
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_0jet_2018","CMS_htt_boson_scale_met_0jet_2018"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"em_0jetlow","em_0jethigh"});
       
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_1jet_2018","CMS_htt_boson_scale_met_1jet_2018"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
 			      {"em_boosted1"});
 
 	  AddShapesIfNotEmpty({"CMS_htt_boson_reso_met_2jet_2018","CMS_htt_boson_scale_met_2jet_2018"},
-			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww125","qqH_hww125"}}),
+			      JoinStr({ggH_STXS,qqH_STXS,{"ZT","ZL","ggH_hww","qqH_hww"}}),
 			      &cb,
 			      1.00,
 			      TheFile,
@@ -254,27 +254,27 @@ int main(int argc, char **argv) {
       // Jet Energy Correction Uncertainties            
       AddShapesIfNotEmpty({"CMS_JetAbsolute","CMS_JetAbsolute_2018","CMS_JetBBEC1","CMS_JetBBEC1_2018","CMS_JetEC2","CMS_JetEC2_2018",
 	    "CMS_JetFlavorQCD","CMS_JetHF","CMS_JetHF_2018","CMS_JetRelativeSample_2018","CMS_JetRelativeBal"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.000,
 	TheFile,CategoryArgs);
       /*
       AddShapesIfNotEmpty({"CMS_JetEta3to5_2018","CMS_JetEta0to5_2018","CMS_JetRelativeBal_2018",
 	    "CMS_JetEta0to3_2018"},
-	    JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","VVT","STL","ZL","TTL","TTT","STT","W"}}),
+	    JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","VVT","STL","ZL","TTL","TTT","STT","W"}}),
 	&cb,
 	0.707,
 	TheFile,CategoryArgs);            
 
       AddShapesIfNotEmpty({"CMS_JetEta3to5","CMS_JetEta0to5","CMS_JetRelativeBal",
             "CMS_JetEta0to3"},
-        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","VVT","STL","ZL","TTL","TTT","STT","W"}}),
+        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","VVT","STL","ZL","TTL","TTT","STT","W"}}),
         &cb,
         0.707,
         TheFile,CategoryArgs);
 
       AddShapesIfNotEmpty({"CMS_JetRelativeSample_2018","CMS_JetEC2_2018"},
-        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","VVT","STL","ZL","TTL","TTT","STT","W"}}),
+        JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","VVT","STL","ZL","TTL","TTT","STT","W"}}),
         &cb,
         1.000,
         TheFile,CategoryArgs);
@@ -282,7 +282,7 @@ int main(int argc, char **argv) {
 
       //JER      
       AddShapesIfNotEmpty({"CMS_JER_2018"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt125","ZH_htt125","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","WH_htt","ZH_htt","VVL","ZL","TTL","VVT","STL","STT","TTT","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 			  &cb,
 			  1.000,
 			  TheFile,CategoryArgs);
@@ -290,7 +290,7 @@ int main(int argc, char **argv) {
       //ggH Theory Uncertainties
       AddShapesIfNotEmpty({"THU_ggH_Mu","THU_ggH_Res","THU_ggH_Mig01","THU_ggH_Mig12","THU_ggH_VBF2j",
 	    "THU_ggH_VBF3j","THU_ggH_qmtop","THU_ggH_PT60","THU_ggH_PT120"},
-	JoinStr({ggH_STXS,{"ggH_hww125"}}),
+	JoinStr({ggH_STXS,{"ggH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);            
@@ -299,21 +299,21 @@ int main(int argc, char **argv) {
       std::cout<<"qqH Theory"<<std::endl;
       AddShapesIfNotEmpty({"THU_qqH_yield","THU_qqH_PTH200","THU_qqH_Mjj60","THU_qqH_Mjj120","THU_qqH_Mjj350","THU_qqH_Mjj700",
 	    "THU_qqH_Mjj1000","THU_qqH_Mjj1500","THU_qqH_PTH25","THU_qqH_JET01"},
-	JoinStr({qqH_STXS,{"qqH_hww125"}}),
+	JoinStr({qqH_STXS,{"qqH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
 
       //Muon Energy scale uncertainties      
       AddShapesIfNotEmpty({"CMS_scale_m_etalt1p2","CMS_scale_m_eta1p2to2p1","CMS_scale_m_eta2p1to2p4"},
-	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+	JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
 	&cb,
 	1.00,
 	TheFile,CategoryArgs);
 
       //Electron Energy scale uncertainties      
       AddShapesIfNotEmpty({"CMS_scale_e"},
-			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt125","ZH_htt125","ggH_hww125","qqH_hww125","WH_hww125","ZH_hww125"}}),
+			  JoinStr({ggH_STXS,qqH_STXS,{"ZT","VVT","STT","TTT","ZL","VVL","STL","TTL","WH_htt","ZH_htt","ggH_hww","qqH_hww","WH_hww","ZH_hww"}}),
         &cb,
         1.00,
         TheFile,CategoryArgs);

--- a/bin/SMHTT2018_et.cpp
+++ b/bin/SMHTT2018_et.cpp
@@ -183,26 +183,26 @@ int main(int argc, char **argv) {
 
       // e to tau energy fake scale            
       /*
-      AddShapesIfNotEmpty({"CMS_scale_efaket_1prong_2018","CMS_scale_efaket_1prong1pizero_2018"},
+      AddShapesIfNotEmpty({"CMS_scale_fake_e_1prong_2018","CMS_scale_fake_e_1prong1pizero_2018"},
 			  {"ZL"},
 			  &cb,
 			  1.00,
 			  TheFile,CategoryArgs);
       */
       std::cout<<"ZLShapes"<<std::endl;
-      AddShapesIfNotEmpty({"CMS_scale_efaket_1prong_barrel_2018",
-	    "CMS_scale_efaket_1prong1pizero_barrel_2018",
-	    "CMS_scale_efaket_1prong_endcap_2018",
-	    "CMS_scale_efaket_1prong1pizero_endcap_2018"},
+      AddShapesIfNotEmpty({"CMS_scale_fake_e_1prong_barrel_2018",
+	    "CMS_scale_fake_e_1prong1pizero_barrel_2018",
+	    "CMS_scale_fake_e_1prong_endcap_2018",
+	    "CMS_scale_fake_e_1prong1pizero_endcap_2018"},
 			  {"ZL"},
 			  &cb,
 			  1.00,
 			  TheFile,CategoryArgs);
 
       
-      AddShapesIfNotEmpty({"CMS_norm_efaket_slice1_2018",
-	    "CMS_norm_efaket_slice2_2018",
-	    "CMS_norm_efaket_slice3_2018"},
+      AddShapesIfNotEmpty({"CMS_norm_fake_e_slice1_2018",
+	    "CMS_norm_fake_e_slice2_2018",
+	    "CMS_norm_fake_e_slice3_2018"},
 			  {"ZL"},
 			  &cb,
 			  1.00,


### PR DESCRIPTION
The following naming schemes have been updated
old->new 

htt_125 -> htt
hww_125 -> hww
pdf_Higgs_qq->pdf_Higgs_qqbar
lumi_Run201->lumi_13TeV_201
scale_emb_t -> scale_t_emb
scale_emb_e-> scale_e_emb
scale_emb_m -> scale_m_emb
mFakeTau -> fake_m
eFakeTau->fake_e
efaket -> fake_e (different systematics strings still displays differently)


How I implemented these results and crossed checked: 
with vim %s/htt_125/htt/gc 